### PR TITLE
Fix edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aurora-chain"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 rocksdb = "0.21"


### PR DESCRIPTION
## Summary
- fix invalid edition in `Cargo.toml`

## Testing
- `cargo check` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68412c0e2dd48325a85c24f713ef1f4e